### PR TITLE
feat: 中国事務所到着日更新時のSlack通知機能

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - 注文状況照会ページから全ページのデータを取得
 - 各注文の詳細ページから商品リンクを取得
 - Google Sheetsに結果を出力
+- 中国事務所到着日の更新時にSlack通知（オプション）
 
 ## 必要な環境変数
 
@@ -30,6 +31,9 @@ YIWU_PASSWORD=your-password
 GOOGLE_SHEETS_CREDENTIALS_JSON=service_account.json
 GOOGLE_SHEETS_SPREADSHEET_ID=your-spreadsheet-id
 GOOGLE_SHEETS_WORKSHEET=yiwu
+
+# Slack 通知設定（オプション）
+SLACK_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/WEBHOOK/URL
 ```
 
 **注意**: `.env`ファイルは機密情報を含むため、Gitにコミットしないでください。
@@ -42,6 +46,7 @@ export YIWU_PASSWORD="your-password"
 export GOOGLE_SHEETS_CREDENTIALS_JSON="service_account.json"
 export GOOGLE_SHEETS_SPREADSHEET_ID="your-spreadsheet-id"
 export GOOGLE_SHEETS_WORKSHEET="yiwu"
+export SLACK_WEBHOOK_URL="https://hooks.slack.com/services/YOUR/WEBHOOK/URL"
 ```
 
 ## ローカル実行
@@ -75,6 +80,24 @@ python yiwu_scraper.py
 ```bash
 gcloud builds submit --config cloudbuild.yaml
 ```
+
+## Slack通知の設定（オプション）
+
+中国事務所到着日の更新時にSlackへ通知を送信できます。
+
+### 設定手順
+
+1. Slack Workspaceで[Incoming Webhooks](https://api.slack.com/messaging/webhooks)を作成
+2. Webhook URLを取得
+3. 環境変数`SLACK_WEBHOOK_URL`にWebhook URLを設定
+
+### 通知のタイミング
+
+以下の場合にSlack通知が送信されます：
+- 既存の注文番号で、中国事務所到着日（F列）が空欄から値ありに変更された場合
+- 新規注文で、中国事務所到着日に初めから値が入っている場合
+
+**注意**: `SLACK_WEBHOOK_URL`が設定されていない場合、通知機能は無効化され、エラーなく動作します。
 
 ## 必要な権限
 

--- a/env.example
+++ b/env.example
@@ -1,0 +1,13 @@
+# イーウーパスポート ログイン情報
+YIWU_USERNAME=your-email@example.com
+YIWU_PASSWORD=your-password
+
+# Google Sheets 設定
+GOOGLE_SHEETS_CREDENTIALS_JSON=service_account.json
+GOOGLE_SHEETS_SPREADSHEET_ID=your-spreadsheet-id
+GOOGLE_SHEETS_WORKSHEET=yiwu
+
+# Slack 通知設定（オプション）
+# Slack Incoming Webhook URLを設定すると、中国事務所到着日の更新時に通知が送信されます
+# 例: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXX
+SLACK_WEBHOOK_URL=

--- a/slack_notifier.py
+++ b/slack_notifier.py
@@ -1,0 +1,81 @@
+"""
+Slack通知モジュール
+中国事務所到着日の更新時にSlackへ通知を送信
+"""
+import os
+import json
+import logging
+from urllib import request, error
+
+logger = logging.getLogger(__name__)
+
+
+class SlackNotifier:
+    """Slack通知クラス"""
+
+    def __init__(self):
+        """
+        環境変数からSlack Webhook URLを取得
+        """
+        self.webhook_url = os.environ.get("SLACK_WEBHOOK_URL")
+        if not self.webhook_url:
+            logger.warning("SLACK_WEBHOOK_URLが設定されていません。Slack通知は無効です。")
+
+    def send_arrival_notification(self, order_id, arrival_date):
+        """
+        中国事務所到着日の更新通知を送信
+
+        Args:
+            order_id: 注文番号
+            arrival_date: 中国事務所到着日
+        """
+        if not self.webhook_url:
+            logger.info(f"Slack通知がスキップされました（注文番号: {order_id}）")
+            return
+
+        try:
+            message = {
+                "text": f"🚚 *中国事務所到着通知*",
+                "blocks": [
+                    {
+                        "type": "header",
+                        "text": {
+                            "type": "plain_text",
+                            "text": "🚚 中国事務所到着通知",
+                            "emoji": True
+                        }
+                    },
+                    {
+                        "type": "section",
+                        "fields": [
+                            {
+                                "type": "mrkdwn",
+                                "text": f"*注文番号:*\n{order_id}"
+                            },
+                            {
+                                "type": "mrkdwn",
+                                "text": f"*到着日:*\n{arrival_date}"
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            # Webhook URLにPOSTリクエストを送信
+            data = json.dumps(message).encode('utf-8')
+            req = request.Request(
+                self.webhook_url,
+                data=data,
+                headers={'Content-Type': 'application/json'}
+            )
+
+            with request.urlopen(req) as response:
+                if response.status == 200:
+                    logger.info(f"Slack通知を送信しました（注文番号: {order_id}）")
+                else:
+                    logger.error(f"Slack通知の送信に失敗しました（ステータス: {response.status}）")
+
+        except error.URLError as e:
+            logger.error(f"Slack通知の送信エラー: {e}")
+        except Exception as e:
+            logger.error(f"Slack通知の送信エラー: {e}")


### PR DESCRIPTION
## 概要

注文番号がGoogleシートにあって、中国事務所到着日が空欄の時、空欄以外を代入する時にSlackに通知する機能を開発しました。

## 変更内容

- `slack_notifier.py`を新規作成
- `google_sheet.py`にSlack通知機能を統合
- `env.example`と`README.md`にドキュメントを追加

Fixes #2

----
Generated with [Claude Code](https://claude.ai/code)